### PR TITLE
jest example warning fixed

### DIFF
--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -1,22 +1,26 @@
 {
   "name": "with-jest",
+  "version": "1.0.0",
+  "jest": {
+    "setupFiles": [
+      "<rootDir>/shim.js"
+    ]
+  },
   "dependencies": {
     "next": "latest",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "devDependencies": {
+    "enzyme": "^2.8.2",
+    "jest": "^21.0.0",
+    "react-addons-test-utils": "^15.6.0",
+    "react-test-renderer": "^16.0.0"
   },
   "scripts": {
     "test": "jest",
     "dev": "next",
     "build": "next build",
     "start": "next start"
-  },
-  "devDependencies": {
-    "babel-jest": "^18.0.0",
-    "enzyme": "^2.5.1",
-    "jest-cli": "^18.0.0",
-    "react-addons-test-utils": "^15.4.2",
-    "babel-preset-es2015": "^6.22.0",
-    "react-test-renderer": "^15.4.2"
   }
 }

--- a/examples/with-jest/shim.js
+++ b/examples/with-jest/shim.js
@@ -1,0 +1,3 @@
+global.requestAnimationFrame = callback => {
+  setTimeout(callback, 0);
+};


### PR DESCRIPTION
I just saw the PR on NextJs and noticed Jest example wasn't updated, I don't know if it was because of the warning:

```
    Warning: React depends on requestAnimationFrame. Make sure that you load a polyfill in older browsers. http://fb.me/react-polyfills

```

But here I updated it without throwing that warning.